### PR TITLE
Move a devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   },
   "dependencies": {
     "amdextract": "^2.0.0",
+    "event-stream": "^3.1.0",
     "through2": "^0.4.1",
     "gulp-util": "~2.2.14"
   },
   "devDependencies": {
     "gulp": "^3.5.6",
-    "event-stream": "^3.1.0",
     "vinyl": "^0.2.3",
     "should": "^3.2.0-beta1",
     "mocha": "~1.18.2"


### PR DESCRIPTION
`event-stream` is used, so the install from npm fails
