### PR TITLE
Update Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.11"
+  - "iojs"
+  - "0.12"
   - "0.10"
 notifications:
   email: false


### PR DESCRIPTION
`0.11` is unstable, and with `0.12` released, there's no need to test it.
