### PR TITLE
Use license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,7 @@
   "bugs": {
     "url": "https://github.com/mehdishojaei/gulp-amdcheck/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/mehdishojaei/gulp-amdcheck/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "main": "index.js",
   "files": ["index.js"],
   "engines": {


### PR DESCRIPTION
Array type is deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license
